### PR TITLE
Method overload

### DIFF
--- a/Sources/Screen/Actions/Generic/ScreenFromAction.swift
+++ b/Sources/Screen/Actions/Generic/ScreenFromAction.swift
@@ -67,12 +67,22 @@ extension ScreenNavigator {
     public func navigate<Output: ScreenContainer>(
         from container: Output?,
         to route: (_ route: ScreenRootRoute<Output>) -> ScreenRouteConvertible,
-        completion: Completion? = nil
+        completion: Completion?
     ) {
         navigate(
             from: container,
             to: route(.initial).route(),
             completion: completion
+        )
+    }
+
+    public func navigate<Output: ScreenContainer>(
+        from container: Output?,
+        to route: (_ route: ScreenRootRoute<Output>) -> ScreenRouteConvertible
+    ) {
+        navigate(
+            from: container,
+            to: route(.initial).route()
         )
     }
 }


### PR DESCRIPTION
ScreenNavigator.navigate() method overload added to fix compiler autocomplete issues